### PR TITLE
Bugfix/uncaught error

### DIFF
--- a/src/Events/Broadcasters/Generic.php
+++ b/src/Events/Broadcasters/Generic.php
@@ -7,7 +7,7 @@ use Neuron\Events\IListener;
 
 class Generic implements IBroadcaster
 {
-	private array $_Listeners;
+	private array $_Listeners = [];
 
 	/**
 	 * @param $Event

--- a/src/Events/Broadcasters/Generic.php
+++ b/src/Events/Broadcasters/Generic.php
@@ -7,6 +7,9 @@ use Neuron\Events\IListener;
 
 class Generic implements IBroadcaster
 {
+	/**
+	 * @var array
+	 */
 	private array $_Listeners = [];
 
 	/**


### PR DESCRIPTION
 Uncaught Error: Typed property Neuron\Events\Broadcasters\Generic::$_Listeners must not be accessed before initialization